### PR TITLE
Add linters to Travis CI configuration

### DIFF
--- a/.bluemix/pipeline.yml
+++ b/.bluemix/pipeline.yml
@@ -1,59 +1,59 @@
 ---
 stages:
-- name: BUILD
-  inputs:
-  - type: git
-    branch: master
-    service: ${SAMPLE_REPO}
-  triggers:
-  - type: commit
-  jobs:
-  - name: Build
-    type: builder
-    artifact_dir: ''
-    build_type: shell
-    script: |-
-      #!/bin/bash
-      bash -n *.sh
-- name: DEPLOY
-  inputs:
-  - type: job
-    stage: BUILD
-    job: Build
-    dir_name: null
-  triggers:
-  - type: stage
-  properties:
-  - name: BLUEMIX_USER
-    type: text
-    value: ${BLUEMIX_USER}
-  - name: BLUEMIX_PASSWORD
-    type: secure
-    value: ${BLUEMIX_PASSWORD}
-  - name: BLUEMIX_ACCOUNT
-    type: secure
-    value: ${BLUEMIX_ACCOUNT}
-  - name: CLUSTER_NAME
-    type: text
-    value: ${CLUSTER_NAME}
-  - name: API_KEY
-    type: secure
-    value: ${API_KEY}
-  jobs:
-  - name: Deploy
-    type: deployer
-    target:
-      region_id: ${PROD_REGION_ID}
-      organization: ${PROD_ORG_NAME}
-      space: ${PROD_SPACE_NAME}
-      application: Pipeline
-    script: |
-      #!/bin/bash
-      . ./scripts/install_bx.sh
-      ./scripts/bx_login.sh
-      ./scripts/deploy.sh
+  - name: BUILD
+    inputs:
+      - type: git
+        branch: master
+        service: ${SAMPLE_REPO}
+    triggers:
+      - type: commit
+    jobs:
+      - name: Build
+        type: builder
+        artifact_dir: ''
+        build_type: shell
+        script: |-
+          #!/bin/bash
+          bash -n *.sh
+  - name: DEPLOY
+    inputs:
+      - type: job
+        stage: BUILD
+        job: Build
+        dir_name: null
+    triggers:
+      - type: stage
+    properties:
+      - name: BLUEMIX_USER
+        type: text
+        value: ${BLUEMIX_USER}
+      - name: BLUEMIX_PASSWORD
+        type: secure
+        value: ${BLUEMIX_PASSWORD}
+      - name: BLUEMIX_ACCOUNT
+        type: secure
+        value: ${BLUEMIX_ACCOUNT}
+      - name: CLUSTER_NAME
+        type: text
+        value: ${CLUSTER_NAME}
+      - name: API_KEY
+        type: secure
+        value: ${API_KEY}
+    jobs:
+      - name: Deploy
+        type: deployer
+        target:
+          region_id: ${PROD_REGION_ID}
+          organization: ${PROD_ORG_NAME}
+          space: ${PROD_SPACE_NAME}
+          application: Pipeline
+        script: |
+          #!/bin/bash
+          . ./scripts/install_bx.sh
+          ./scripts/bx_login.sh
+          ./scripts/deploy.sh
 hooks:
-- enabled: true
-  label: null
-  ssl_enabled: false
-  url: https://devops-api-integration.stage1.ng.bluemix.net/v1/messaging/webhook/publish
+  - enabled: true
+    label: null
+    ssl_enabled: false
+    url: https://devops-api-integration.stage1.ng.bluemix.net/v1/messaging/webhook/publish

--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -10,40 +10,40 @@ required:
 
 # Github repos
 sample-repo:
-  service_id: githubpublic
-  parameters:
-    repo_name: "{{name}}"
-    repo_url: https://github.com/IBM/Kubernetes-container-service-GitLab-sample
-    type: clone
-    has_issues: false
+ service_id: githubpublic
+ parameters:
+  repo_name: "{{name}}"
+  repo_url: https://github.com/IBM/Kubernetes-container-service-GitLab-sample
+  type: clone
+  has_issues: false
 
 # Pipelines
 sample-build:
-  service_id: pipeline
-  parameters:
-    name: "{{name}}"
-    ui-pipeline: true
-    configuration:
-     content: $file(pipeline.yml)
-     env:
-      SAMPLE_REPO: "sample-repo"
-      CF_APP_NAME: "{{deploy.parameters.prod-app-name}}"
-      PROD_SPACE_NAME: "{{deploy.parameters.prod-space}}"
-      PROD_ORG_NAME: "{{deploy.parameters.prod-organization}}"
-      PROD_REGION_ID: "{{deploy.parameters.prod-region}}"
-      BLUEMIX_USER: "{{deploy.parameters.bluemix-user}}"
-      BLUEMIX_PASSWORD: "{{deploy.parameters.bluemix-password}}"
-      API_KEY: "{{deploy.parameters.bluemix-api-key}}"
-      BLUEMIX_ACCOUNT: "{{deploy.parameters.bluemix-cluster-account}}"
-      CLUSTER_NAME: "{{deploy.parameters.bluemix-cluster-name}}"
-     execute: true
-    services: ["sample-repo"]
-  hidden: [form, description]
+ service_id: pipeline
+ parameters:
+  name: "{{name}}"
+  ui-pipeline: true
+  configuration:
+   content: $file(pipeline.yml)
+   env:
+    SAMPLE_REPO: "sample-repo"
+    CF_APP_NAME: "{{deploy.parameters.prod-app-name}}"
+    PROD_SPACE_NAME: "{{deploy.parameters.prod-space}}"
+    PROD_ORG_NAME: "{{deploy.parameters.prod-organization}}"
+    PROD_REGION_ID: "{{deploy.parameters.prod-region}}"
+    BLUEMIX_USER: "{{deploy.parameters.bluemix-user}}"
+    BLUEMIX_PASSWORD: "{{deploy.parameters.bluemix-password}}"
+    API_KEY: "{{deploy.parameters.bluemix-api-key}}"
+    BLUEMIX_ACCOUNT: "{{deploy.parameters.bluemix-cluster-account}}"
+    CLUSTER_NAME: "{{deploy.parameters.bluemix-cluster-name}}"
+   execute: true
+  services: ["sample-repo"]
+ hidden: [form, description]
 
-#Deployment
+# Deployment
 deploy:
-  schema:
-    $ref: deploy.json
-  service-category: pipeline
-  parameters:
-    prod-app-name: "{{sample-repo.parameters.repo_name}}"
+ schema:
+  $ref: deploy.json
+ service-category: pipeline
+ parameters:
+  prod-app-name: "{{sample-repo.parameters.repo_name}}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,28 @@
+---
+language: python
+python: 2.7
 sudo: required
+
+addons:
+  apt:
+    sources:
+      - debian-sid
+    packages:
+      - shellcheck
+
+install:
+  - pip install -U pip
+  - pip install yamllint
+  - wget http://public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli/Bluemix_CLI_0.5.1_amd64.tar.gz
+    -O /tmp/bx.tar.gz
+  - tar xf /tmp/bx.tar.gz -C /tmp
+  - sudo /tmp/Bluemix_CLI/install_bluemix_cli
+  - curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+  - chmod +x kubectl
+  - sudo mv kubectl /usr/local/bin
+
 before_script:
-- wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key |
-  sudo apt-key add -
-- echo "deb http://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
-- sudo apt-get update
-- sudo apt-get install cf-cli -y
-- wget http://public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli/Bluemix_CLI_0.5.1_amd64.tar.gz
-  -O /tmp/bx.tar.gz
-- tar xf /tmp/bx.tar.gz -C /tmp
-- sudo /tmp/Bluemix_CLI/install_bluemix_cli
-- curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
-- chmod +x kubectl
-- sudo mv kubectl /usr/local/bin
+  - "./tests/test-shellcheck.sh"
+  - "./tests/test-yamllint.sh"
+
 script: true
-env:
-  global:
-  - secure: JWfW2aekuP73UUyVrUpvltnN5SPaIrDKYzcH7V54TzjDkZ/98a9nu15te5e1WRUb1W0gZtYnQexfLjdJjtweGMSFvfR0J44MYQt2a2qOExHPU6zYvrIpt91mHKvX3ymjCVVkhxfv85IXKTAsXy2DDFw7WvDBdauwdEIqDauU8EnnRzdSP21UVOA2aMn+RZp2aUziUXDOqZIIzDvzLs3V0VrAuHEyLsttPkijV9KrMFYkOGMpNYzQInfJOSo/6QkaiIwUntP++LQRTWWpFpX8K2N1rTmr4GVcF3jww2u+0E6Pl282n26KFOMU3RMbi+9gq3jqKPlbHT/uXRnmISwBhi70+s9WUxSrYH7cUFOEHohWtUUfsEwf5l9bk6pgQ8cazeKdS869EG67Y8PKMJ0NaQUGDzLm+0l1DL5CJboJYuT9OEVPcqsaP5/YegRmNkiaUmobIJUN65lbPFnLJJXq28EHfndHT/EHVFuhbb0a86459SWeGL23Sqc3zKfsQdkqcvwEVPQUyNF/pk4udii1g4UqOYsr57q1fKdYnT6EXUbubsqvk+vwkTeXEjycIdgE+3SRJ1+8C5RqGgMo/CZooddVzzT55hAcyy6JrOCNcdGh3zZm87J6uVUgSCOzVXLVfo8OVG+VJEIWydgDH9pNtGArSsmevg2JXbVpbev98LA=
-  - secure: YTUTRQYxCXpzcAnuSCJbicySYOPmqBVTIaqglpFluDBV9XnT5I0UAnHOZdB/Dp0EcQNrT/ML9y+Hwpo7P7Cc7bOqhezhb4GQkh27bb8QBKoG36mD6hIFpS0agNFJMS6Knw+ORf8kAWr2jyth0tEhC8zum+Uis3BqNvbL3KYDOL+HjSfffI5gk1d1ASbaqApLHpEyN2pewqFOYfyz7ZD5GK5cc8dwSk7JvuUqWqYZH9Bd7MgKa8aPcVgjrmiuTsCMyQe9Fjd18x36iYs9N4z0I2Qz7XkD30J/gCVC/tKbXpAWzC9BAyFUY806MDGGpT4XKVgUkkKPO78nBEz1s/A4WrW7x4/Vlfh5IYTEGLu2N9o7e33RE5Ec38JDmGHR6yL9SjIqkq6SxEK76xOsBtwkmxyYHZmsmjPaW20VWXmdzrAXxckNggmM8wgf1jHk4E7vlKzrjmd5N278HuKF0tr5Sxrf8LVxMAS7pbUnUa26xut2On+ITYd4Vn4XJ9bLCO9reQOfvsOHTjbHNq5JwXK1QXNL5LV1vjcXw5S0H+xTovlRC8phk7NeWReZuFeT+h2ksHlsYH8R8e8fT+nNlXy/uoPrWXVobJAjowh5V7oOchm/0i5/jrzAFV6ON3ZrUqrOOYSQbZ3h/4jQf0UP63oPbBr17xgbtsAmXB4RipQ0ktc=
-  - secure: GPG087lVaNdjHOpv2obmGY+DhxCwz700E8Mo7Yer9ZrXHcnYN9V0dh/fRMU8C04aNW2ZvNa6RNZl/BNMKgQfPx+eEjpX0k8kqJ5fEFgFv7GMWacX89fzAf9mRoqoFV5YnIn/7QMOcN6Mgh5hNPEFRX30VkOrTAm7v/ykRLeoXUVpyhhy1d2Ig/Cv+e67Gz4vQmSoTvKAULBhge5hbMfkK2yutOuSu5hGUj+oCmQDzFHjb4+L4TwQoz58iN0SYc3QHQPTdUJEg+bQvIz7nMNX9koH3EtXo3WCxyqgCTYrfp9pVZaCiWC7EyuA3I15fzBr5aLI0y4bpMBQMLbviskkI5CqyJMavEDPyb285UshoxoLQ9FuPEIepBKpHMZxJQKZ90434cmav9DrlQnU0aApVJMFlHnS6Qg0+UAwyCQsooSe5GzWsJP5UXLrETaHwg1Y+migc73xkE/PkiO0FQxll7z2L3imnMLO3vymW6p2FkpnynrkQelsiSuVx7J5aU88L2gyBwyopwHppgbK/sWlXmB6S2of9T5YB2lZwycxqi6P0WF9jyxazJOLfU2McJ/6BeU8KYXnzTKdpqT4XKuvAa8L7Mlk4Utd1f/Ng0wuh4L8ZU7gU6j/KC1KoQwOCvbl3YjKf5Vc8EYvnUkEfI8OLm0EWLfZdmo3+1oKmDjI9Po=

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,47 @@
+---
+rules:
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: 0
+    max-spaces-inside-empty: 0
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: 0
+    max-spaces-inside-empty: 0
+  colons:
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments:
+    require-starting-space: true
+    min-spaces-from-content: 2
+  comments-indentation: enable
+  document-end: disable
+  document-start:
+    present: true
+  empty-lines:
+    max: 2
+    max-start: 0
+    max-end: 0
+  hyphens:
+    max-spaces-after: 1
+  indentation:
+    spaces: consistent
+    indent-sequences: true
+    check-multi-line-strings: false
+  key-duplicates: enable
+  line-length:
+    max: 80
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true
+    level: warning
+  new-line-at-end-of-file: enable
+  new-lines:
+    type: unix
+  trailing-spaces: enable
+  truthy: enable

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+---
 gitlab:
   image: 'gitlab/gitlab-ce:9.1.0-ce.0'
   restart: always
@@ -21,9 +22,9 @@ gitlab:
       external_url 'http://gitlab.example.com:30080'
       gitlab_rails['gitlab_shell_ssh_port'] = 30022
   ports:
-# both ports must match the port from external_url above
+    # both ports must match the port from external_url above
     - "30080:30080"
-# the mapped port must match ssh_port specified above.
+    # the mapped port must match ssh_port specified above.
     - "30022:22"
 # the following are hints on what volumes to mount if you want to persist data
 #  volumes:
@@ -45,7 +46,3 @@ postgresql:
 redis:
   restart: always
   image: redis:3.0.7-alpine
-
-
-
-

--- a/scripts/bx_login.sh
+++ b/scripts/bx_login.sh
@@ -1,35 +1,31 @@
-#!/bin/sh
+#!/bin/bash
 
-if [ -z $CF_ORG ]; then
+if [[ -z "$CF_ORG" ]]; then
   CF_ORG="$BLUEMIX_ORG"
 fi
-if [ -z $CF_SPACE ]; then
+if [[ -z "$CF_SPACE" ]]; then
   CF_SPACE="$BLUEMIX_SPACE"
 fi
 
 
-if ([ -z "$BLUEMIX_USER" ] || [ -z "$BLUEMIX_PASSWORD" ] || [ -z "$BLUEMIX_ACCOUNT" ]) && ([ -z "$API_KEY"]); then
+if ([ -z "$BLUEMIX_USER" ] || [ -z "$BLUEMIX_PASSWORD" ] || [ -z "$BLUEMIX_ACCOUNT" ]) && ([ -z "$API_KEY" ]); then
   echo "Define all required environment variables and re-run the stage."
   exit 1
 fi
 
 echo "bx login -a $CF_TARGET_URL"
 
-if [ -z "$API_KEY"]; then
-  bx login -a "$CF_TARGET_URL" -u "$BLUEMIX_USER" -p "$BLUEMIX_PASSWORD" -c "$BLUEMIX_ACCOUNT" -o "$CF_ORG" -s "$CF_SPACE"
+if [[ -z "$API_KEY" ]]; then
+  bx login -a "$CF_TARGET_URL" -u "$BLUEMIX_USER" -p "$BLUEMIX_PASSWORD" -c "$BLUEMIX_ACCOUNT" -o "$CF_ORG" -s "$CF_SPACE" \
+      || echo "Failed to authenticate to Bluemix"
 else
-  bx login -a "$CF_TARGET_URL" --apikey "$API_KEY" -o "$CF_ORG" -s "$CF_SPACE"
+  bx login -a "$CF_TARGET_URL" --apikey "$API_KEY" -o "$CF_ORG" -s "$CF_SPACE" \
+      || echo "Failed to authenticate to Bluemix"
 fi
 
-if [ $? -ne 0 ]; then
-  echo "Failed to authenticate to Bluemix"
-  exit 1
-fi
-
-# Init container clusters
 echo "bx cs init"
-bx cs init
-if [ $? -ne 0 ]; then
+
+if ! bx cs init ; then
   echo "Failed to initialize to Bluemix Container Service"
   exit 1
 fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,15 +1,14 @@
 #!/bin/bash
 
 echo "Create Gitlab"
-IP_ADDR=$(bx cs workers $CLUSTER_NAME | grep Ready | awk '{ print $2 }')
-if [ -z $IP_ADDR ]; then
+IP_ADDR=$(bx cs workers "$CLUSTER_NAME" | grep Ready | awk '{ print $2 }')
+if [[ -z "$IP_ADDR" ]]; then
   echo "$CLUSTER_NAME not created or workers not ready"
   exit 1
 fi
 
 echo -e "Configuring vars"
-exp=$(bx cs cluster-config $CLUSTER_NAME | grep export)
-if [ $? -ne 0 ]; then
+if ! exp=$(bx cs cluster-config "$CLUSTER_NAME" | grep export); then
   echo "Cluster $CLUSTER_NAME not created or not ready."
   exit 1
 fi

--- a/scripts/install_bx.sh
+++ b/scripts/install_bx.sh
@@ -5,9 +5,9 @@ wget --quiet --output-document=/tmp/Bluemix_CLI_amd64.tar.gz  http://public.dhe.
 tar -xf /tmp/Bluemix_CLI_amd64.tar.gz --directory=/tmp
 
 # Create bx alias
-echo "#!/bin/sh" >/tmp/Bluemix_CLI/bin/bx
-echo "/tmp/Bluemix_CLI/bin/bluemix \"\$@\" " >>/tmp/Bluemix_CLI/bin/bx
-chmod +x /tmp/Bluemix_CLI/bin/*
+echo "#!/bin/sh" > /tmp/Bluemix_CLI/bin/bx
+echo "/tmp/Bluemix_CLI/bin/bluemix \"\$@\" " >> /tmp/Bluemix_CLI/bin/bx
+chmod 0755 /tmp/Bluemix_CLI/bin/*
 
 export PATH="/tmp/Bluemix_CLI/bin:$PATH"
 
@@ -15,10 +15,10 @@ echo "Install the Bluemix container-service plugin"
 bx plugin install container-service -r Bluemix
 
 echo "Install kubectl"
-wget --quiet --output-document=/tmp/Bluemix_CLI/bin/kubectl  https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+wget --quiet --output-document=/tmp/Bluemix_CLI/bin/kubectl  https://storage.googleapis.com/kubernetes-release/release/"$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)"/bin/linux/amd64/kubectl
 chmod +x /tmp/Bluemix_CLI/bin/kubectl
 
-if [ -n "$DEBUG" ]; then
+if [[ -n "$DEBUG" ]]; then
   bx --version
   bx plugin list
 fi

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -22,13 +22,13 @@ function run_tests() {
 	sleep 20
 
 	RUNNING=$(kubectl get pods | grep -c Running)
-	if [ $RUNNING -ne 3 ]; then
+	if [ "$RUNNING" -ne 3 ]; then
 		exit_tests 1
 	fi;
 
 	sleep 60
 	IP=$(kubectl get nodes | awk 'NR>1 {print $1}')
-	curl -f http://$IP:30080 -o /dev/null || exit_tests 1
+	curl -f http://"$IP":30080 -o /dev/null || exit_tests 1
 
 
 	exit_tests 0
@@ -37,7 +37,7 @@ function run_tests() {
 function exit_tests() {
 	kubectl delete pv local-volume-1 local-volume-2 local-volume-3
 	kubectl delete deployment,service,pvc -l app=gitlab
-	exit $1
+	exit 1
 }
 
 

--- a/tests/test-shellcheck.sh
+++ b/tests/test-shellcheck.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+if find . -name '*.sh' -print0 | xargs -n1 -0 shellcheck -x -s bash; then
+    echo -e "\033[0;32mShell script linting passed!\033[0m"
+else
+    echo -e >&2 "\033[0;31mShell script linting failed!\033[0m"
+    exit 1
+fi
+

--- a/tests/test-yamllint.sh
+++ b/tests/test-yamllint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+if find . -name '*.yml' -print0 | xargs -n1 -0 yamllint -c .yamllint.yml; then
+    echo -e "\033[0;32mYAML linting passed!\033[0m"
+else
+    echo -e >&2 "\033[0;31mYAML linting failed!\033[0m"
+    exit 1
+fi
+


### PR DESCRIPTION
Previously, Travis CI installed software (some of which was not needed),
and then ran `/bin/true`.

Now, the Travis CI configuration has been cleaned up, and runs
shellcheck and yamllint. In the process, several .sh and .yml files had
to be updated so that they would pass linting.

Related-Issue: IBM/Kubernetes-container-service-GitLab-sample#26
Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>