### PR TITLE
Add docker-compose test to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: python
 python: 2.7
 sudo: required
 
+services:
+  - docker
+
 addons:
   apt:
     sources:
@@ -25,4 +28,5 @@ before_script:
   - "./tests/test-shellcheck.sh"
   - "./tests/test-yamllint.sh"
 
-script: true
+script:
+  - "./tests/test-docker-compose.sh"

--- a/tests/test-docker-compose.sh
+++ b/tests/test-docker-compose.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+test_failed(){
+    echo -e >&2 "\033[0;31mdocker-compose test failed!\033[0m"
+    exit 1
+}
+
+test_passed(){
+    echo -e "\033[0;32mdocker-compose test passed!\033[0m"
+}
+
+main(){
+    if ! docker-compose up -d; then
+        test_failed
+    elif ! docker-compose ps; then
+        test_failed
+    elif ! nc -z -v localhost 30080; then
+        test_failed
+    else
+        test_passed
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
Now we run docker-compose and check that port 30080 is listening on
every Travis CI run.

Related-Issue: IBM/Kubernetes-container-service-GitLab-sample#26
Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>