### PR TITLE
Support standard YAML file extensions

### DIFF
--- a/kubernetes/gitlab-postgres-svc.yaml
+++ b/kubernetes/gitlab-postgres-svc.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -50,34 +51,34 @@ spec:
         tier: frontend
     spec:
       containers:
-      - image: gitlab/gitlab-ce:9.1.0-ce.0
-        name: gitlab
-        env:
-        - name: GITLAB_OMNIBUS_CONFIG
-          value: |
-            postgresql['enable'] = false
-            gitlab_rails['db_username'] = "admin"
-        # Update with password from Compose for PostgreSQL password credential
-            gitlab_rails['db_password'] = "COMPOSE_PG_PASSWORD"
-        # Update with password from Compose for PostgreSQL host endpoint
-            gitlab_rails['db_host'] = "COMPOSE_PG_HOST"
-        # Update with password from Compose for PostgreSQL service port
-            gitlab_rails['db_port'] = "COMPOSE_PG_PORT"
-            gitlab_rails['db_database'] = "compose"
-            gitlab_rails['db_adapter'] = 'postgresql'
-            gitlab_rails['db_encoding'] = 'utf8'
-            redis['enable'] = false
-            gitlab_rails['redis_host'] = 'redis'
-            gitlab_rails['redis_port'] = '6379'
-            gitlab_rails['gitlab_shell_ssh_port'] = 30022
-            external_url 'http://gitlab.example.com:30080'
-        ports:
-        - containerPort: 30080
+        - image: gitlab/gitlab-ce:9.1.0-ce.0
           name: gitlab
-        volumeMounts:
-        - name: gitlab
-          mountPath: /home/git/data:rw
+          env:
+            - name: GITLAB_OMNIBUS_CONFIG
+              value: |
+                postgresql['enable'] = false
+                gitlab_rails['db_username'] = "admin"
+                # Update with password from Compose for PostgreSQL password
+                gitlab_rails['db_password'] = "COMPOSE_PG_PASSWORD"
+                # Update with password from Compose for PostgreSQL host endpoint
+                gitlab_rails['db_host'] = "COMPOSE_PG_HOST"
+                # Update with password from Compose for PostgreSQL service port
+                gitlab_rails['db_port'] = "COMPOSE_PG_PORT"
+                gitlab_rails['db_database'] = "compose"
+                gitlab_rails['db_adapter'] = 'postgresql'
+                gitlab_rails['db_encoding'] = 'utf8'
+                redis['enable'] = false
+                gitlab_rails['redis_host'] = 'redis'
+                gitlab_rails['redis_port'] = '6379'
+                gitlab_rails['gitlab_shell_ssh_port'] = 30022
+                external_url 'http://gitlab.example.com:30080'
+          ports:
+            - containerPort: 30080
+              name: gitlab
+          volumeMounts:
+            - name: gitlab
+              mountPath: /home/git/data:rw
       volumes:
-      - name: gitlab
-        persistentVolumeClaim:
-          claimName: gitlab-claim
+        - name: gitlab
+          persistentVolumeClaim:
+            claimName: gitlab-claim

--- a/kubernetes/gitlab.yaml
+++ b/kubernetes/gitlab.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -50,31 +51,31 @@ spec:
         tier: frontend
     spec:
       containers:
-      - image: gitlab/gitlab-ce:9.1.0-ce.0
-        name: gitlab
-        env:
-        - name: GITLAB_OMNIBUS_CONFIG
-          value: |
-            postgresql['enable'] = false
-            gitlab_rails['db_username'] = "gitlab"
-            gitlab_rails['db_password'] = "gitlab"
-            gitlab_rails['db_host'] = "postgresql"
-            gitlab_rails['db_port'] = "5432"
-            gitlab_rails['db_database'] = "gitlabhq_production"
-            gitlab_rails['db_adapter'] = 'postgresql'
-            gitlab_rails['db_encoding'] = 'utf8'
-            redis['enable'] = false
-            gitlab_rails['redis_host'] = 'redis'
-            gitlab_rails['redis_port'] = '6379'
-            gitlab_rails['gitlab_shell_ssh_port'] = 30022
-            external_url 'http://gitlab.example.com:30080'
-        ports:
-        - containerPort: 30080
+        - image: gitlab/gitlab-ce:9.1.0-ce.0
           name: gitlab
-        volumeMounts:
-        - name: gitlab
-          mountPath: /home/git/data:rw
+          env:
+            - name: GITLAB_OMNIBUS_CONFIG
+              value: |
+                postgresql['enable'] = false
+                gitlab_rails['db_username'] = "gitlab"
+                gitlab_rails['db_password'] = "gitlab"
+                gitlab_rails['db_host'] = "postgresql"
+                gitlab_rails['db_port'] = "5432"
+                gitlab_rails['db_database'] = "gitlabhq_production"
+                gitlab_rails['db_adapter'] = 'postgresql'
+                gitlab_rails['db_encoding'] = 'utf8'
+                redis['enable'] = false
+                gitlab_rails['redis_host'] = 'redis'
+                gitlab_rails['redis_port'] = '6379'
+                gitlab_rails['gitlab_shell_ssh_port'] = 30022
+                external_url 'http://gitlab.example.com:30080'
+          ports:
+            - containerPort: 30080
+              name: gitlab
+          volumeMounts:
+            - name: gitlab
+              mountPath: /home/git/data:rw
       volumes:
-      - name: gitlab
-        persistentVolumeClaim:
-          claimName: gitlab-claim
+        - name: gitlab
+          persistentVolumeClaim:
+            claimName: gitlab-claim

--- a/kubernetes/local-volumes.yaml
+++ b/kubernetes/local-volumes.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/kubernetes/postgres.yaml
+++ b/kubernetes/postgres.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -40,22 +41,22 @@ spec:
         tier: postgreSQL
     spec:
       containers:
-      - image: postgres:9.6.2-alpine
-        name: postgresql
-        env:
-          - name: POSTGRES_USER
-            value : gitlab
-          - name: POSTGRES_DB
-            value : gitlabhq_production
-          - name: POSTGRES_PASSWORD
-            value: gitlab
-        ports:
-        - containerPort: 5432
+        - image: postgres:9.6.2-alpine
           name: postgresql
-        volumeMounts:
-        - name: postgresql
-          mountPath: /var/lib/postgresql:rw
+          env:
+            - name: POSTGRES_USER
+              value: gitlab
+            - name: POSTGRES_DB
+              value: gitlabhq_production
+            - name: POSTGRES_PASSWORD
+              value: gitlab
+          ports:
+            - containerPort: 5432
+              name: postgresql
+          volumeMounts:
+            - name: postgresql
+              mountPath: /var/lib/postgresql:rw
       volumes:
-      - name: postgresql
-        persistentVolumeClaim:
-          claimName: postgres-claim
+        - name: postgresql
+          persistentVolumeClaim:
+            claimName: postgres-claim

--- a/kubernetes/redis.yaml
+++ b/kubernetes/redis.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -41,15 +42,15 @@ spec:
         tier: backend
     spec:
       containers:
-      - image: redis:3.0.7-alpine
-        name: redis
-        ports:
-        - containerPort: 6379
+        - image: redis:3.0.7-alpine
           name: redis
-        volumeMounts:
-        - name: redis
-          mountPath: /var/lib/redis:rw
+          ports:
+            - containerPort: 6379
+              name: redis
+          volumeMounts:
+            - name: redis
+              mountPath: /var/lib/redis:rw
       volumes:
-      - name: redis
-        persistentVolumeClaim:
-          claimName: redis-claim
+        - name: redis
+          persistentVolumeClaim:
+            claimName: redis-claim

--- a/tests/test-yamllint.sh
+++ b/tests/test-yamllint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-if find . -name '*.yml' -print0 | xargs -n1 -0 yamllint -c .yamllint.yml; then
+if find . \( -name '*.yml' -o -name '*.yaml' \) -print0 | xargs -n1 -0 yamllint -c .yamllint.yml; then
     echo -e "\033[0;32mYAML linting passed!\033[0m"
 else
     echo -e >&2 "\033[0;31mYAML linting failed!\033[0m"


### PR DESCRIPTION
Previously, we were not linting files with the .yaml file extension.
Now, we are.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>