### PR TITLE
Set gitlab ServiceType to LoadBalancer

### DIFF
--- a/kubernetes/gitlab.yaml
+++ b/kubernetes/gitlab.yaml
@@ -20,7 +20,7 @@ spec:
   selector:
     app: gitlab
     tier: frontend
-  type: NodePort
+  type: LoadBalancer
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim


### PR DESCRIPTION
Previously, we were setting ServiceType to NodePort, which caused the
gitlab service to not be exposed during deployment. Now, we are using
LoadBalancer, which allows the service to be reached from the outside.

Related-Issue: IBM/Kubernetes-container-service-GitLab-sample#36
Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>