### PR TITLE
Change docker-compose test to use cURL

### DIFF
--- a/tests/test-docker-compose.sh
+++ b/tests/test-docker-compose.sh
@@ -14,7 +14,7 @@ main(){
         test_failed
     elif ! docker-compose ps; then
         test_failed
-    elif ! nc -z -v localhost 30080; then
+    elif ! sleep 1 && curl -sS localhost:30080; then
         test_failed
     else
         test_passed


### PR DESCRIPTION
tests/test-docker-compose.sh now uses cURL to match how
tests/test-kubernetes.sh checks that the service is available.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>