### PR TITLE
Use regex like we know what we're doing

### DIFF
--- a/tests/test-kubernetes.sh
+++ b/tests/test-kubernetes.sh
@@ -49,7 +49,7 @@ kubectl_deploy() {
 }
 
 verify_deploy(){
-    IPS=$(bx cs workers "$CLUSTER_NAME" | awk '{ print $2 }' | grep -v Public | grep .)
+    IPS=$(bx cs workers "$CLUSTER_NAME" | awk '{ print $2 }' | grep '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}')
     for IP in $IPS; do
         if ! curl -sS "$IP":30080; then
             test_failed


### PR DESCRIPTION
Previously we were not grepping efficiently for bx work public IPs in
tests/test-kubernetes.sh. Now we are awking for column two and grepping
for IPv4 addresses in that field.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>