### PR TITLE
Update bx version in Travis configuration

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,7 +6,7 @@ if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
 fi
 
 echo "Install Bluemix CLI"
-curl -L public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli/Bluemix_CLI_0.5.6_amd64.tar.gz > Bluemix_CLI.tar.gz
+curl -L https://public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli/latest/Bluemix_CLI_amd64.tar.gz > Bluemix_CLI.tar.gz
 tar -xvf Bluemix_CLI.tar.gz
 sudo ./Bluemix_CLI/install_bluemix_cli
 


### PR DESCRIPTION
We were receiving failures in Travis CI due to an old version of the
Bluemix CLI client being installed. Now that has been fixed.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>