### PR TITLE
Configure ICP install to use dynamic storage

### DIFF
--- a/charts/gitlab-omnibus/.helmignore
+++ b/charts/gitlab-omnibus/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/gitlab-omnibus/CHANGELOG.md
+++ b/charts/gitlab-omnibus/CHANGELOG.md
@@ -1,0 +1,11 @@
+**0.1.35**
+> Upgrade note: 
+* Due to the change in default access mode, existing users will have to specify `ReadWriteMany` as the access mode. For example:
+```
+gitlabDataAccessMode=ReadWriteMany
+gitlabRegistryAccessMode=ReadWriteMany
+gitlabConfigAccessMode=ReadWriteMany
+```
+
+* Sets the default access mode for `gitlab-storage`, `gitlab-registry-storage`, and `gitlab-config-storage` to be `ReadWriteOnce` to be compatible with Kubernetes 1.7.0+. 
+* The parameter name to configure the size of the `gitlab-storage` PVC has changed from `gitlabRailsStorageSize` to `gitlabDataStorageSize`. For backwards compatability, `gitlabRailsStorageSize` will still apply provided `gitlabDataStorageSize` is undefined.

--- a/charts/gitlab-omnibus/Chart.yaml
+++ b/charts/gitlab-omnibus/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+description: GitLab Omnibus all-in-one bundle
+home: https://about.gitlab.com
+icon: https://gitlab.com/gitlab-com/gitlab-artwork/raw/master/logo/logo-square.png
+keywords:
+- git
+- ci
+- cd
+- deploy
+- issue tracker
+- code review
+- wiki
+maintainers:
+- email: support@gitlab.com
+  name: GitLab Inc.
+- name: Mark Pundsack
+- name: Jason Plum
+- name: DJ Mountney
+- name: Joshua Lambert
+name: gitlab-omnibus
+sources:
+- http://docs.gitlab.com/ce/install/kubernetes/
+- https://gitlab.com/charts/charts.gitlab.io
+tillerVersion: '>=2.5.0'
+version: 0.1.37

--- a/charts/gitlab-omnibus/README.md
+++ b/charts/gitlab-omnibus/README.md
@@ -1,0 +1,7 @@
+> This chart is beta. We are building a set of Cloud Native
+charts at [helm.gitlab.io](https://gitlab.com/charts/helm.gitlab.io). The goal of that work
+is to fully replace this chart.
+
+# GitLab-Omnibus Helm Chart
+
+This chart is the easiest way to get started with GitLab on Kubernetes. It includes everything needed to run GitLab, including: a Runner, Container Registry, automatic SSL, and an Ingress. For more information, please review [our documentation](http://docs.gitlab.com/ee/install/kubernetes/gitlab_omnibus.html).

--- a/charts/gitlab-omnibus/charts/gitlab-runner/.helmignore
+++ b/charts/gitlab-omnibus/charts/gitlab-runner/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/gitlab-omnibus/charts/gitlab-runner/Chart.yaml
+++ b/charts/gitlab-omnibus/charts/gitlab-runner/Chart.yaml
@@ -1,0 +1,16 @@
+description: GitLab Runner
+icon: https://gitlab.com/uploads/-/system/project/avatar/250833/runner_logo.png
+keywords:
+- git
+- ci
+- deploy
+maintainers:
+- email: support@gitlab.com
+  name: GitLab Inc.
+- email: dj@gitlab.com
+  name: DJ Mountney
+name: gitlab-runner
+sources:
+- https://hub.docker.com/r/gitlab/gitlab-runner/
+- https://docs.gitlab.com/runner/
+version: 0.1.13

--- a/charts/gitlab-omnibus/charts/gitlab-runner/README.md
+++ b/charts/gitlab-omnibus/charts/gitlab-runner/README.md
@@ -1,0 +1,7 @@
+> This chart is beta. We are building a set of Cloud Native
+charts at [helm.gitlab.io](https://gitlab.com/charts/helm.gitlab.io). The goal of that work
+is to fully replace this chart.
+
+# GitLab Runner Helm Chart
+
+This chart deploys a GitLab Runner instance into your Kubernetes cluster. For more information, please review [our documentation](http://docs.gitlab.com/ee/install/kubernetes/gitlab_runner_chart.html).

--- a/charts/gitlab-omnibus/charts/gitlab-runner/templates/NOTES.txt
+++ b/charts/gitlab-omnibus/charts/gitlab-runner/templates/NOTES.txt
@@ -1,0 +1,27 @@
+{{- if include "gitlabUrl" . }}
+{{- if default "" .Values.runnerRegistrationToken }}
+Your GitLab Runner should now be registered against the GitLab instance reachable at: {{ template "gitlabUrl" . }}
+{{- else -}}
+##############################################################################
+## WARNING: You did not specify an runnerRegistrationToken in your 'helm install' call. ##
+##############################################################################
+
+This deployment will be incomplete until you provide the Registration Token for your
+GitLab instance:
+
+    helm upgrade {{ .Release.Name }} \
+        --set gitlabUrl=http://gitlab.your-domain.com,runnerRegistrationToken=your-registration-token \
+        stable/gitlab-runner
+{{- end -}}
+{{- else -}}
+##############################################################################
+## WARNING: You did not specify an gitlabUrl in your 'helm install' call. ##
+##############################################################################
+
+This deployment will be incomplete until you provide the URL that your
+GitLab instance is reachable at:
+
+    helm upgrade {{ .Release.Name }} \
+        --set gitlabUrl=http://gitlab.your-domain.com,runnerRegistrationToken=your-registration-token \
+        stable/gitlab-runner
+{{- end -}}

--- a/charts/gitlab-omnibus/charts/gitlab-runner/templates/_helpers.tpl
+++ b/charts/gitlab-omnibus/charts/gitlab-runner/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Template for outputing the gitlabUrl
+*/}}
+{{- define "gitlabUrl" -}}
+{{- .Values.gitlabUrl | quote -}}
+{{- end -}}

--- a/charts/gitlab-omnibus/charts/gitlab-runner/templates/configmap.yaml
+++ b/charts/gitlab-omnibus/charts/gitlab-runner/templates/configmap.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  entrypoint: |
+    #!/bin/bash
+
+    set -xe
+
+    cp /scripts/config.toml /etc/gitlab-runner/
+
+    # Register the runner
+    /entrypoint register --non-interactive \
+      --url $GITLAB_URL \
+      --executor kubernetes
+
+    # Start the runner
+    /entrypoint run --user=gitlab-runner \
+      --working-directory=/home/gitlab-runner
+  config.toml: |
+    concurrent = {{ .Values.concurrent }}
+    check_interval = {{ .Values.checkInterval }}

--- a/charts/gitlab-omnibus/charts/gitlab-runner/templates/deployment.yaml
+++ b/charts/gitlab-omnibus/charts/gitlab-runner/templates/deployment.yaml
@@ -1,0 +1,104 @@
+{{- if and (include "gitlabUrl" .) (default "" .Values.runnerRegistrationToken) }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+    spec:
+      containers:
+      - name: {{ template "fullname" . }}
+        image: {{ .Values.image }}
+        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        command: ["/bin/bash", "/scripts/entrypoint"]
+        env:
+        - name: GITLAB_URL
+          value: {{ template "gitlabUrl" . }}
+        - name: REGISTRATION_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}
+              key: runner-registration-token
+        - name: KUBERNETES_IMAGE
+          value: {{ .Values.runners.image | quote }}
+        {{ if .Values.runners.privileged }}
+        - name: KUBERNETES_PRIVILEGED
+          value: "true"
+        {{ end }}
+        - name: KUBERNETES_NAMESPACE
+          value: {{ default .Release.Namespace .Values.runners.namespace | quote }}
+        - name: KUBERNETES_CPU_LIMIT
+          value: {{ default "" .Values.runners.builds.cpuLimit | quote }}
+        - name: KUBERNETES_MEMORY_LIMIT
+          value: {{ default "" .Values.runners.builds.memoryLimit | quote }}
+        - name: KUBERNETES_CPU_REQUEST
+          value: {{ default "" .Values.runners.builds.cpuRequests | quote }}
+        - name: KUBERNETES_MEMORY_REQUEST
+          value: {{ default "" .Values.runners.builds.memoryRequests| quote }}
+        - name: KUBERNETES_SERVICE_CPU_LIMIT
+          value: {{ default "" .Values.runners.services.cpuLimit | quote }}
+        - name: KUBERNETES_SERVICE_MEMORY_LIMIT
+          value: {{ default "" .Values.runners.services.memoryLimit | quote }}
+        - name: KUBERNETES_SERVICE_CPU_REQUEST
+          value: {{ default "" .Values.runners.services.cpuRequests | quote }}
+        - name: KUBERNETES_SERVICE_MEMORY_REQUEST
+          value: {{ default "" .Values.runners.services.memoryRequests | quote }}
+        - name: KUBERNETES_HELPERS_CPU_LIMIT
+          value: {{ default "" .Values.runners.helpers.cpuLimit | quote }}
+        - name: KUBERNETES_HELPERS_MEMORY_LIMIT
+          value: {{ default "" .Values.runners.helpers.memoryLimit | quote }}
+        - name: KUBERNETES_HELPERS_CPU_REQUEST
+          value: {{ default "" .Values.runners.helpers.cpuRequests | quote }}
+        - name: KUBERNETES_HELPERS_MEMORY_REQUEST
+          value: {{ default "" .Values.runners.helpers.memoryRequests| quote }}
+        livenessProbe:
+          exec:
+            command: ["/usr/bin/pgrep","gitlab.*runner"]
+          initialDelaySeconds: 60
+          timeoutSeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/pgrep","gitlab.*runner"]
+          initialDelaySeconds: 10
+          timeoutSeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+        volumeMounts:
+        - name: scripts
+          mountPath: /scripts
+        {{- if .Values.certsSecretName }}
+        - name: custom-certs
+          readOnly: true
+          mountPath: /etc/gitlab-runner/certs/
+        {{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+      volumes:
+      {{ if .Values.runners.privileged }}
+      - name: var-run-docker-sock
+        hostPath:
+          path: /var/run/docker.sock
+      {{ end }}
+      {{- if .Values.certsSecretName }}
+      - name: custom-certs
+        secret:
+          secretName: {{ .Values.certsSecretName }}
+      {{- end }}
+      - name: scripts
+        configMap:
+          name: {{ template "fullname" . }}
+{{ else }}
+{{ end }}

--- a/charts/gitlab-omnibus/charts/gitlab-runner/templates/secrets.yaml
+++ b/charts/gitlab-omnibus/charts/gitlab-runner/templates/secrets.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  runner-registration-token: {{ default "" .Values.runnerRegistrationToken | b64enc | quote }}

--- a/charts/gitlab-omnibus/charts/gitlab-runner/values.yaml
+++ b/charts/gitlab-omnibus/charts/gitlab-runner/values.yaml
@@ -1,0 +1,91 @@
+## GitLab Runner Image
+## ref: https://hub.docker.com/r/gitlab/gitlab-runner/tags/
+##
+image: gitlab/gitlab-runner:alpine-v9.5.0
+
+## Specify a imagePullPolicy
+## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
+## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+##
+# imagePullPolicy:
+
+## The GitLab Server URL (with protocol) that want to register the runner against
+## ref: https://docs.gitlab.com/runner/commands/README.html#gitlab-runner-register
+##
+# gitlabUrl: http://gitlab.your-domain.com/
+
+## The Registration Token for adding new Runners to the GitLab Server. This must
+## be retreived from your GitLab Instance.
+## ref: https://docs.gitlab.com/ce/ci/runners/README.html#creating-and-registering-a-runner
+##
+# runnerRegistrationToken: ""
+
+## Set the certsSecretName in order to pass custom certficates for GitLab Runner to use
+## Provide resource name for a Kubernetes Secret Object in the same namespace,
+## this is used to populate the /etc/gitlab-runner/certs directory
+## ref: https://docs.gitlab.com/runner/configuration/tls-self-signed.html#supported-options-for-self-signed-certificates
+##
+# certsSecretName:
+
+## Configure the maximum number of concurrent jobs
+## ref: https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-global-section
+##
+concurrent: 10
+
+## Defines in seconds how often to check GitLab for a new builds
+## ref: https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-global-section
+##
+checkInterval: 30
+
+## Configuration for the Pods that that the runner launches for each new job
+##
+runners:
+  ## Default container image to use for builds when none is specified
+  ##
+  image: ubuntu:16.04
+
+  ## Run all containers with the privileged flag enabled
+  ## This will allow the docker:dind image to run if you need to run Docker
+  ## commands. Please read the docs before turning this on:
+  ## ref: https://docs.gitlab.com/runner/executors/kubernetes.html#using-docker-dind
+  ##
+  privileged: false
+
+  ## Namespace to run Kubernetes jobs in (defaults to 'default')
+  ##
+  # namespace:
+
+  ## Build Container specific configuration
+  ##
+  builds: {}
+    # cpuLimit: 200m
+    # memoryLimit: 256Mi
+    # cpuRequests: 100m
+    # memoryRequests: 128Mi
+
+  ## Service Container specific configuration
+  ##
+  services: {}
+    # cpuLimit: 200m
+    # memoryLimit: 256Mi
+    # cpuRequests: 100m
+    # memoryRequests: 128Mi
+
+  ## Helper Container specific configuration
+  ##
+  helpers: {}
+    # cpuLimit: 200m
+    # memoryLimit: 256Mi
+    # cpuRequests: 100m
+    # memoryRequests: 128Mi
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources: {}
+  # limits:
+  #   memory: 256Mi
+  #   cpu: 200m
+  # requests:
+  #   memory: 128Mi
+  #   cpu: 100m

--- a/charts/gitlab-omnibus/requirements.lock
+++ b/charts/gitlab-omnibus/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: gitlab-runner
+  repository: https://charts.gitlab.io/
+  version: 0.1.13
+digest: sha256:0aee2695db7d33f0d894372aedde81e5675c72ac058393f3c0f29182b15b5065
+generated: 2017-11-01T19:14:29.27678802-07:00

--- a/charts/gitlab-omnibus/requirements.yaml
+++ b/charts/gitlab-omnibus/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: gitlab-runner
+  version: 0.1.13
+  repository: https://charts.gitlab.io/

--- a/charts/gitlab-omnibus/templates/NOTES.txt
+++ b/charts/gitlab-omnibus/templates/NOTES.txt
@@ -1,0 +1,28 @@
+{{- if and (default "" .Values.baseDomain) (default "" .Values.legoEmail) }}
+  It may take several minutes for GitLab to reconfigure.
+    You can watch the status by running `kubectl get deployment -w {{ template "fullname" . }} --namespace {{ .Release.Namespace }}
+
+  {{- if .Values.baseIP }}
+  Make sure to configure DNS with something like:
+    *.{{ .Values.baseDomain }}	300 IN A {{ .Values.baseIP }}
+  {{- else }}
+  You did not specify a baseIP so one will be assigned for you.
+  It may take a few minutes for the LoadBalancer IP to be available.
+  Watch the status with: 'kubectl get svc -w --namespace nginx-ingress nginx', then:
+
+  export SERVICE_IP=$(kubectl get svc --namespace nginx-ingress nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+
+  Then make sure to configure DNS with something like:
+    *.{{ .Values.baseDomain }}	300 IN A $SERVICE_IP
+  {{- end }}
+{{- else }}
+####################################################################################################
+## WARNING: You did not specify an baseDomain, gitlab-runner.gitlabUrl, and legoEmail in your 'helm install' call. ##
+####################################################################################################
+
+This deployment will be incomplete until you provide these variables:
+
+$ helm upgrade {{ .Release.Name }} \
+  --set baseDomain=example.com,gitlab-runner.gitlabUrl=https://gitlab.example.com,legoEmail=you@example.com \
+  gitlab/kubernetes-gitlab-demo
+{{- end -}}

--- a/charts/gitlab-omnibus/templates/_helpers.tpl
+++ b/charts/gitlab-omnibus/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified postgresql name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "postgresql.fullname" -}}
+{{- $appName := (include "fullname" .) | trunc 54 | trimSuffix "-" -}}
+{{- printf "%s-%s" $appName "postgresql" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified redis name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "redis.fullname" -}}
+{{- $appName := (include "fullname" .) | trunc 57 | trimSuffix "-" -}}
+{{- printf "%s-%s" $appName "redis" -}}
+{{- end -}}
+
+{{/*
+Template for outputing the gitlabUrl
+*/}}
+{{- define "gitlabUrl" -}}
+{{- if .Values.gitlabUrl -}}
+{{- .Values.gitlabUrl | quote -}}
+{{- else -}}
+{{- printf "http://%s-gitlab.%s:8005/" .Release.Name .Release.Namespace | quote -}}
+{{- end -}}
+{{- end -}}

--- a/charts/gitlab-omnibus/templates/fast-storage/storage.yaml
+++ b/charts/gitlab-omnibus/templates/fast-storage/storage.yaml
@@ -1,0 +1,20 @@
+{{- if (eq .Values.provider "gke") }}
+kind: StorageClass
+apiVersion: {{ if .Capabilities.APIVersions.Has "storage.k8s.io/v1" }}storage.k8s.io/v1{{ else }}storage.k8s.io/v1beta1{{ end }}
+metadata:
+  name: {{ template "fullname" . }}-fast
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "false"
+  labels:
+    kubernetes.io/cluster-service: "true"
+{{- if eq .Values.provider "gke" }}
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+{{- end }}
+{{- end }}

--- a/charts/gitlab-omnibus/templates/gitlab-config.yaml
+++ b/charts/gitlab-omnibus/templates/gitlab-config.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}-config
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  external_scheme: {{ .Values.externalScheme }}
+  external_hostname: gitlab.{{ .Values.baseDomain }}
+  registry_external_scheme: {{ .Values.externalScheme }}
+  registry_external_hostname: registry.{{ .Values.baseDomain }}
+  mattermost_external_scheme: {{ .Values.externalScheme }}
+  mattermost_external_hostname: mattermost.{{ .Values.baseDomain }}
+  mattermost_app_uid: {{ .Values.mattermostAppUID }}
+  postgres_user: gitlab
+  postgres_db: gitlab_production
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}-secrets
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  postgres_password: {{ .Values.postgresPassword }}
+  initial_shared_runners_registration_token: {{ default "" .Values.initialSharedRunnersRegistrationToken | b64enc | quote }}
+  mattermost_app_secret: {{ .Values.mattermostAppSecret | b64enc | quote }}
+{{- if .Values.gitlabEELicense }}
+  gitlab_ee_license: {{ .Values.gitlabEELicense | b64enc | quote }}
+{{- end }}

--- a/charts/gitlab-omnibus/templates/gitlab/gitlab-config-storage.yaml
+++ b/charts/gitlab-omnibus/templates/gitlab/gitlab-config-storage.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "fullname" . }}-config-storage
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+  {{- if .Values.gitlabConfigStorageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.gitlabConfigStorageClass | quote }}
+  {{- else if (eq .Values.provider "gke") }}
+    volume.beta.kubernetes.io/storage-class: {{ template "fullname" . }}-fast
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
+spec:
+  accessModes:
+    - {{ default "ReadWriteOnce" .Values.gitlabConfigAccessMode | quote }}
+  resources:
+    requests:
+      storage: {{ default "1Gi" .Values.gitlabConfigStorageSize }}

--- a/charts/gitlab-omnibus/templates/gitlab/gitlab-deployment.yaml
+++ b/charts/gitlab-omnibus/templates/gitlab/gitlab-deployment.yaml
@@ -1,0 +1,222 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+        name: {{ template "fullname" . }}
+    spec:
+      containers:
+      - name: gitlab
+        {{- if eq .Values.gitlab "ee" }}
+        image: {{ .Values.gitlabEEImage }}
+        {{- else }}
+        image: {{ .Values.gitlabCEImage }}
+        {{- end }}
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/bash", "-c",
+          "sed -i \"s/environment ({'GITLAB_ROOT_PASSWORD' => initial_root_password }) if initial_root_password/environment ({'GITLAB_ROOT_PASSWORD' => initial_root_password, 'GITLAB_SHARED_RUNNERS_REGISTRATION_TOKEN' => node['gitlab']['gitlab-rails']['initial_shared_runners_registration_token'] })/g\" /opt/gitlab/embedded/cookbooks/gitlab/recipes/database_migrations.rb && exec /assets/wrapper"]
+        env:
+        - name: GITLAB_EXTERNAL_SCHEME
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "fullname" . }}-config
+              key: external_scheme
+        - name: GITLAB_EXTERNAL_HOSTNAME
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "fullname" . }}-config
+              key: external_hostname
+        - name: GITLAB_REGISTRY_EXTERNAL_SCHEME
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "fullname" . }}-config
+              key: registry_external_scheme
+        - name: GITLAB_REGISTRY_EXTERNAL_HOSTNAME
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "fullname" . }}-config
+              key: registry_external_hostname
+        - name: GITLAB_MATTERMOST_EXTERNAL_SCHEME
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "fullname" . }}-config
+              key: mattermost_external_scheme
+        - name: GITLAB_MATTERMOST_EXTERNAL_HOSTNAME
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "fullname" . }}-config
+              key: mattermost_external_hostname
+        - name: POSTGRES_USER
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "fullname" . }}-config
+              key: postgres_user
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}-secrets
+              key: postgres_password
+        - name: POSTGRES_DB
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "fullname" . }}-config
+              key: postgres_db
+        - name: GITLAB_INITIAL_SHARED_RUNNERS_REGISTRATION_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}-secrets
+              key: initial_shared_runners_registration_token
+        - name: MATTERMOST_APP_UID
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "fullname" . }}-config
+              key: mattermost_app_uid
+        - name: MATTERMOST_APP_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}-secrets
+              key: mattermost_app_secret
+        {{- if .Values.gitlabEELicense }}
+        - name: GITLAB_EE_LICENSE
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}-secrets
+              key: gitlab_ee_license
+        {{- end }}
+        - name: GITLAB_OMNIBUS_CONFIG
+          value: |
+            external_url "#{ENV['GITLAB_EXTERNAL_SCHEME']}://#{ENV['GITLAB_EXTERNAL_HOSTNAME']}"
+            registry_external_url "#{ENV['GITLAB_REGISTRY_EXTERNAL_SCHEME']}://#{ENV['GITLAB_REGISTRY_EXTERNAL_HOSTNAME']}"
+            mattermost_external_url "#{ENV['GITLAB_MATTERMOST_EXTERNAL_SCHEME']}://#{ENV['GITLAB_MATTERMOST_EXTERNAL_HOSTNAME']}"
+
+            gitlab_rails['initial_shared_runners_registration_token'] = ENV['GITLAB_INITIAL_SHARED_RUNNERS_REGISTRATION_TOKEN']
+
+            nginx['enable'] = false
+            registry_nginx['enable'] = false
+            mattermost_nginx['enable'] = false
+
+            gitlab_workhorse['listen_network'] = 'tcp'
+            gitlab_workhorse['listen_addr'] = '0.0.0.0:8005'
+
+            mattermost['service_address'] = '0.0.0.0'
+            mattermost['service_port'] = '8065'
+
+            registry['registry_http_addr'] = '0.0.0.0:8105'
+
+            postgresql['enable'] = false
+            gitlab_rails['db_host'] = '{{ template "postgresql.fullname" . }}'
+            gitlab_rails['db_password'] = ENV['POSTGRES_PASSWORD']
+            gitlab_rails['db_username'] = ENV['POSTGRES_USER']
+            gitlab_rails['db_database'] = ENV['POSTGRES_DB']
+
+            redis['enable'] = false
+            gitlab_rails['redis_host'] = '{{ template "redis.fullname" . }}'
+
+            mattermost['file_directory'] = '/gitlab-data/mattermost';
+            mattermost['sql_driver_name'] = 'postgres';
+            mattermost['sql_data_source'] = "user=#{ENV['POSTGRES_USER']} host={{ template "postgresql.fullname" . }} port=5432 dbname=mattermost_production password=#{ENV['POSTGRES_PASSWORD']} sslmode=disable";
+            mattermost['gitlab_enable'] = true;
+            mattermost['gitlab_secret'] = ENV['MATTERMOST_APP_SECRET'];
+            mattermost['gitlab_id'] = ENV['MATTERMOST_APP_UID'];
+            mattermost['gitlab_scope'] = '';
+            mattermost['gitlab_auth_endpoint'] = "#{ENV['GITLAB_EXTERNAL_SCHEME']}://#{ENV['GITLAB_EXTERNAL_HOSTNAME']}/oauth/authorize";
+            mattermost['gitlab_token_endpoint'] = "#{ENV['GITLAB_EXTERNAL_SCHEME']}://#{ENV['GITLAB_EXTERNAL_HOSTNAME']}/oauth/token";
+            mattermost['gitlab_user_api_endpoint'] = "#{ENV['GITLAB_EXTERNAL_SCHEME']}://#{ENV['GITLAB_EXTERNAL_HOSTNAME']}/api/v4/user"
+
+            manage_accounts['enable'] = true
+            manage_storage_directories['manage_etc'] = false
+
+            gitlab_shell['auth_file'] = '/gitlab-data/ssh/authorized_keys'
+            git_data_dirs({ "default" => { "path" => "/gitlab-data/git-data" } })
+            gitlab_rails['shared_path'] = '/gitlab-data/shared'
+            gitlab_rails['uploads_directory'] = '/gitlab-data/uploads'
+            gitlab_ci['builds_directory'] = '/gitlab-data/builds'
+            gitlab_rails['registry_path'] = '/gitlab-registry'
+            gitlab_rails['trusted_proxies'] = ["10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"]
+
+            prometheus['listen_address'] = '0.0.0.0:9090'
+            postgres_exporter['enable'] = true
+            postgres_exporter['env'] = {
+              'DATA_SOURCE_NAME' => "user=#{ENV['POSTGRES_USER']} host={{ template "postgresql.fullname" . }} port=5432 dbname=#{ENV['POSTGRES_DB']} password=#{ENV['POSTGRES_PASSWORD']} sslmode=disable"
+            }
+            redis_exporter['enable'] = true
+            redis_exporter['flags'] = {
+              'redis.addr' => "{{ template "redis.fullname" . }}:6379",
+            }
+        - name: GITLAB_POST_RECONFIGURE_CODE
+          value: |
+            include Gitlab::CurrentSettings
+
+            Doorkeeper::Application.where(uid: ENV["MATTERMOST_APP_UID"]).first_or_create(
+              name: "GitLab Mattermost",
+              secret: ENV["MATTERMOST_APP_SECRET"],
+              redirect_uri: "#{ENV["GITLAB_MATTERMOST_EXTERNAL_SCHEME"]}://#{ENV["GITLAB_MATTERMOST_EXTERNAL_HOSTNAME"]}/signup/gitlab/complete\r\n#{ENV["GITLAB_MATTERMOST_EXTERNAL_SCHEME"]}://#{ENV["GITLAB_MATTERMOST_EXTERNAL_HOSTNAME"]}/login/gitlab/complete")
+
+            PrometheusService.where(template: true).first_or_create(
+              active: true, api_url: "http://localhost:9090")
+
+            KubernetesService.where(template: true).first_or_create(
+              active: true,
+              api_url: "https://#{ENV["KUBERNETES_SERVICE_HOST"]}:#{ENV["KUBERNETES_SERVICE_PORT"]}",
+              token: File.read("/var/run/secrets/kubernetes.io/serviceaccount/token"),
+              ca_pem: File.read("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"))
+
+            current_application_settings.update_attribute(:health_check_access_token, '{{.Values.healthCheckToken}}')
+
+            {{- if .Values.gitlabEELicense }}
+            License.first_or_create(data: "#{ENV["GITLAB_EE_LICENSE"]}")
+            {{- end }}
+        - name: GITLAB_POST_RECONFIGURE_SCRIPT
+          value: |
+            /opt/gitlab/bin/gitlab-rails runner -e production "$GITLAB_POST_RECONFIGURE_CODE"
+        ports:
+        - name: registry
+          containerPort: 8105
+        - name: mattermost
+          containerPort: 8065
+        - name: workhorse
+          containerPort: 8005
+        - name: ssh
+          containerPort: 22
+        - name: prometheus
+          containerPort: 9090
+        volumeMounts:
+        - name: config
+          mountPath: /etc/gitlab
+        - name: data
+          mountPath: /gitlab-data
+          subPath: gitlab-data
+        - name: registry
+          mountPath: /gitlab-registry
+        livenessProbe:
+          httpGet:
+            path: /health_check?token={{.Values.healthCheckToken}}
+            port: 8005
+          initialDelaySeconds: 180
+          timeoutSeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /health_check?token={{.Values.healthCheckToken}}
+            port: 8005
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: {{ template "fullname" . }}-storage
+      - name: registry
+        persistentVolumeClaim:
+          claimName: {{ template "fullname" . }}-registry-storage
+      - name: config
+        persistentVolumeClaim:
+          claimName: {{ template "fullname" . }}-config-storage

--- a/charts/gitlab-omnibus/templates/gitlab/gitlab-storage.yaml
+++ b/charts/gitlab-omnibus/templates/gitlab/gitlab-storage.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "fullname" . }}-storage
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+  {{- if .Values.gitlabDataStorageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.gitlabDataStorageClass | quote }}
+  {{- else if (eq .Values.provider "gke") }}
+    volume.beta.kubernetes.io/storage-class: {{ template "fullname" . }}-fast
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
+spec:
+  accessModes:
+    - {{ default "ReadWriteOnce" .Values.gitlabDataAccessMode | quote }}
+  resources:
+    requests:
+      # Fallback to supporting older value: gitlabRailsStorageSize when the new one is not set
+      storage: {{ coalesce .Values.gitlabDataStorageSize .Values.gitlabRailsStorageSize "30Gi" }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "fullname" . }}-registry-storage
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+  {{- if .Values.gitlabRegistryStorageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.gitlabRegistryStorageClass | quote }}
+  {{- else if (eq .Values.provider "gke") }}
+    volume.beta.kubernetes.io/storage-class: {{ template "fullname" . }}-fast
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
+spec:
+  accessModes:
+    - {{ default "ReadWriteOnce" .Values.gitlabRegistryAccessMode | quote }}
+  resources:
+    requests:
+      storage: {{ default "30Gi" .Values.gitlabRegistryStorageSize }}

--- a/charts/gitlab-omnibus/templates/gitlab/gitlab-svc.yaml
+++ b/charts/gitlab-omnibus/templates/gitlab/gitlab-svc.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  selector:
+    name: {{ template "fullname" . }}
+  ports:
+    - name: ssh
+      port: 22
+      targetPort: ssh
+    - name: mattermost
+      port: 8065
+      targetPort: mattermost
+    - name: registry
+      port: 8105
+      targetPort: registry
+    - name: workhorse
+      port: 8005
+      targetPort: workhorse
+    - name: prometheus
+      port: 9090
+      targetPort: prometheus

--- a/charts/gitlab-omnibus/templates/gitlab/postgresql-configmap.yaml
+++ b/charts/gitlab-omnibus/templates/gitlab/postgresql-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "postgresql.fullname" . }}-initdb
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  01_create_mattermost_production.sql: |
+    CREATE DATABASE mattermost_production WITH OWNER gitlab;

--- a/charts/gitlab-omnibus/templates/gitlab/postgresql-deployment.yaml
+++ b/charts/gitlab-omnibus/templates/gitlab/postgresql-deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "postgresql.fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+        name: {{ template "postgresql.fullname" . }}
+    spec:
+      containers:
+      - name: postgresql
+        image: {{ .Values.postgresImage }}
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: POSTGRES_USER
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "fullname" . }}-config
+              key: postgres_user
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" . }}-secrets
+              key: postgres_password
+        - name: POSTGRES_DB
+          valueFrom:
+            configMapKeyRef:
+              name: {{ template "fullname" . }}-config
+              key: postgres_db
+        - name: DB_EXTENSION
+          value: pg_trgm
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
+        ports:
+        - name: postgres
+          containerPort: 5432
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: data
+          subPath: postgres
+        - mountPath: /docker-entrypoint-initdb.d
+          name: initdb
+          readOnly: true
+        livenessProbe:
+          exec:
+            command:
+            - pg_isready
+            - -h
+            - localhost
+            - -U
+            - postgres
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+            - pg_isready
+            - -h
+            - localhost
+            - -U
+            - postgres
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: {{ if .Values.postgresDedicatedStorage }} {{ template "postgresql.fullname" . }}-storage {{ else }} {{ template "fullname" . }}-storage {{ end }}
+      - name: initdb
+        configMap:
+          name: {{ template "postgresql.fullname" . }}-initdb

--- a/charts/gitlab-omnibus/templates/gitlab/postgresql-storage.yaml
+++ b/charts/gitlab-omnibus/templates/gitlab/postgresql-storage.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.postgresDedicatedStorage }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "postgresql.fullname" . }}-storage
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+  {{- if .Values.postgresStorageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.postgresStorageClass | quote }}
+  {{- else if (eq .Values.provider "gke") }}
+    volume.beta.kubernetes.io/storage-class: {{ template "fullname" . }}-fast
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
+spec:
+  accessModes:
+    - {{ default "ReadWriteOnce" .Values.postgresAccessMode | quote }}
+  resources:
+    requests:
+      storage: {{ default "30Gi" .Values.postgresStorageSize }}
+{{- end }}

--- a/charts/gitlab-omnibus/templates/gitlab/postgresql-svc.yaml
+++ b/charts/gitlab-omnibus/templates/gitlab/postgresql-svc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "postgresql.fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+  selector:
+    name: {{ template "postgresql.fullname" . }}

--- a/charts/gitlab-omnibus/templates/gitlab/redis-deployment.yaml
+++ b/charts/gitlab-omnibus/templates/gitlab/redis-deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "redis.fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: {{ template "redis.fullname" . }}
+        app: {{ template "fullname" . }}
+    spec:
+      containers:
+      - name: redis
+        image: {{ .Values.redisImage }}
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: redis
+          containerPort: 6379
+        volumeMounts:
+        - mountPath: /var/lib/redis
+          name: data
+          subPath: redis
+        livenessProbe:
+          exec:
+            command:
+            - redis-cli
+            - ping
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+            - redis-cli
+            - ping
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: {{ if .Values.redisDedicatedStorage }} {{ template "redis.fullname" . }}-storage {{ else }} {{ template "fullname" . }}-storage {{ end }}

--- a/charts/gitlab-omnibus/templates/gitlab/redis-storage.yaml
+++ b/charts/gitlab-omnibus/templates/gitlab/redis-storage.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.redisDedicatedStorage }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "redis.fullname" . }}-storage
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+  {{- if .Values.redisStorageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.redisStorageClass | quote }}
+  {{- else if (eq .Values.provider "gke") }}
+    volume.beta.kubernetes.io/storage-class: {{ template "fullname" . }}-fast
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
+spec:
+  accessModes:
+    - {{ default "ReadWriteOnce" .Values.redisAccessMode | quote }}
+  resources:
+    requests:
+      storage: {{ default "5Gi" .Values.redisStorageSize }}
+{{- end }}

--- a/charts/gitlab-omnibus/templates/gitlab/redis-svc.yaml
+++ b/charts/gitlab-omnibus/templates/gitlab/redis-svc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "redis.fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  selector:
+    name:  {{ template "redis.fullname" . }}
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: redis

--- a/charts/gitlab-omnibus/templates/ingress/gitlab-ingress.yaml
+++ b/charts/gitlab-omnibus/templates/ingress/gitlab-ingress.yaml
@@ -1,0 +1,50 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - hosts:
+    - gitlab.{{ .Values.baseDomain }}
+    - registry.{{ .Values.baseDomain }}
+    - mattermost.{{ .Values.baseDomain }}
+    - prometheus.{{ .Values.baseDomain }}
+    secretName: gitlab-tls
+  rules:
+  - host: gitlab.{{ .Values.baseDomain }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ template "fullname" . }}
+          servicePort: 8005
+  - host: registry.{{ .Values.baseDomain }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ template "fullname" . }}
+          servicePort: 8105
+  - host: mattermost.{{ .Values.baseDomain }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ template "fullname" . }}
+          servicePort: 8065
+  - host: prometheus.{{ .Values.baseDomain }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ template "fullname" . }}
+          servicePort: 9090
+---

--- a/charts/gitlab-omnibus/templates/load-balancer/lego/00-namespace.yaml
+++ b/charts/gitlab-omnibus/templates/load-balancer/lego/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-lego

--- a/charts/gitlab-omnibus/templates/load-balancer/lego/configmap.yaml
+++ b/charts/gitlab-omnibus/templates/load-balancer/lego/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+metadata:
+  name: kube-lego
+  namespace: kube-lego
+data:
+  # modify this to specify your address
+  lego.email: "{{ .Values.legoEmail }}"
+  # configure letencrypt's production api
+  lego.url: "https://acme-v01.api.letsencrypt.org/directory"
+kind: ConfigMap

--- a/charts/gitlab-omnibus/templates/load-balancer/lego/deployment.yaml
+++ b/charts/gitlab-omnibus/templates/load-balancer/lego/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-lego
+  namespace: kube-lego
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: kube-lego
+    spec:
+      containers:
+      - name: kube-lego
+        image: jetstack/kube-lego:0.1.3
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+        env:
+        - name: LEGO_EMAIL
+          valueFrom:
+            configMapKeyRef:
+              name: kube-lego
+              key: lego.email
+        - name: LEGO_URL
+          valueFrom:
+            configMapKeyRef:
+              name: kube-lego
+              key: lego.url
+        - name: LEGO_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LEGO_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 1

--- a/charts/gitlab-omnibus/templates/load-balancer/nginx/00-namespace.yaml
+++ b/charts/gitlab-omnibus/templates/load-balancer/nginx/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nginx-ingress

--- a/charts/gitlab-omnibus/templates/load-balancer/nginx/configmap.yaml
+++ b/charts/gitlab-omnibus/templates/load-balancer/nginx/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+data:
+  proxy-connect-timeout: "15"
+  proxy-read-timeout: "600"
+  proxy-send-timeout: "600"
+  hsts-include-subdomains: "false"
+  proxy-body-size: "1024m"
+  server-name-hash-bucket-size: "256"
+  enable-vts-status: "true"
+kind: ConfigMap
+metadata:
+  namespace: nginx-ingress
+  name: nginx

--- a/charts/gitlab-omnibus/templates/load-balancer/nginx/daemonset.yaml
+++ b/charts/gitlab-omnibus/templates/load-balancer/nginx/daemonset.yaml
@@ -1,0 +1,45 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: nginx
+  namespace: nginx-ingress
+spec:
+  template:
+    metadata:
+      labels:
+        app: nginx
+      annotations:
+        prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
+    spec:
+      containers:
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11
+        name: nginx
+        imagePullPolicy: Always
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 80
+        - containerPort: 443
+        - containerPort: 22
+        - containerPort: 18080
+        - containerPort: 10254
+        args:
+        - /nginx-ingress-controller
+        - --default-backend-service=nginx-ingress/default-http-backend
+        - --configmap=nginx-ingress/nginx
+        - --tcp-services-configmap=nginx-ingress/tcp-ports

--- a/charts/gitlab-omnibus/templates/load-balancer/nginx/default-deployment.yaml
+++ b/charts/gitlab-omnibus/templates/load-balancer/nginx/default-deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: default-http-backend
+  namespace: nginx-ingress
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: default-http-backend
+    spec:
+      containers:
+      - name: default-http-backend
+        # Any image is permissable as long as:
+        # 1. It serves a 404 page at /
+        # 2. It serves 200 on a /healthz endpoint
+        image: gcr.io/google_containers/defaultbackend:1.0
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi

--- a/charts/gitlab-omnibus/templates/load-balancer/nginx/default-service.yaml
+++ b/charts/gitlab-omnibus/templates/load-balancer/nginx/default-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-http-backend
+  namespace: nginx-ingress
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    app: default-http-backend

--- a/charts/gitlab-omnibus/templates/load-balancer/nginx/service.yaml
+++ b/charts/gitlab-omnibus/templates/load-balancer/nginx/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  namespace: nginx-ingress
+  annotations:
+    service.beta.kubernetes.io/external-traffic: "OnlyLocal"
+spec:
+  type: LoadBalancer
+{{- if .Values.baseIP }}
+  loadBalancerIP: {{ .Values.baseIP }}
+{{- end }}
+  ports:
+  - port: 80
+    name: http
+  - port: 443
+    name: https
+  - port: 22
+    name: git
+  selector:
+    app: nginx
+apiVersion: v1

--- a/charts/gitlab-omnibus/templates/load-balancer/nginx/tcp-configmap.yaml
+++ b/charts/gitlab-omnibus/templates/load-balancer/nginx/tcp-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tcp-ports
+  namespace: nginx-ingress
+data:
+  22: "{{ .Release.Namespace }}/{{ template "fullname" . }}:22"

--- a/charts/gitlab-omnibus/values.yaml
+++ b/charts/gitlab-omnibus/values.yaml
@@ -1,0 +1,101 @@
+# Default values for kubernetes-gitlab-demo.
+# This is a YAML-formatted file.
+
+# Required variables
+
+# baseDomain is the top-most part of the domain. Subdomains will be generated
+# for gitlab, mattermost, registry, and prometheus.
+# Recommended to set up an A record on the DNS to *.your-domain.com to point to
+# the baseIP
+# e.g. *.your-domain.com.	A	300	baseIP
+#baseDomain: your-domain.com
+
+# legoEmail is a valid email address used by Let's Encrypt. It does not have to
+# be at the baseDomain.
+#legoEmail: you@example.com
+
+# Optional variables
+# baseIP is an externally provisioned static IP address to use instead of the provisioned one.
+#baseIP: 1.1.1.1
+
+# Allow override of scheme through Values
+externalScheme: https
+
+nameOverride: gitlab
+# `ce` or `ee`
+gitlab: ce
+gitlabCEImage: gitlab/gitlab-ce:10.1.0-ce.0
+gitlabEEImage: gitlab/gitlab-ee:10.1.0-ee.0
+postgresPassword: NDl1ZjNtenMxcWR6NXZnbw==
+initialSharedRunnersRegistrationToken: "tQtCbx5UZy_ByS7FyzUH"
+mattermostAppSecret: NDl1ZjNtenMxcWR6NXZnbw==
+mattermostAppUID: aadas
+redisImage: redis:3.2.10
+redisDedicatedStorage: true
+#redisStorageSize: 5Gi
+redisAccessMode: ReadWriteOnce
+postgresImage: postgres:9.6.5
+# If you disable postgresDedicatedStorage, you should consider bumping up gitlabRailsStorageSize
+postgresDedicatedStorage: true
+postgresAccessMode: ReadWriteOnce
+#postgresStorageSize: 30Gi
+gitlabDataAccessMode: ReadWriteOnce
+#gitlabDataStorageSize: 30Gi
+gitlabRegistryAccessMode: ReadWriteOnce
+#gitlabRegistryStorageSize: 30Gi
+gitlabConfigAccessMode: ReadWriteOnce
+#gitlabConfigStorageSize: 1Gi
+gitlabRunnerImage: gitlab/gitlab-runner:alpine-v10.1.0
+# Valid values for provider are `gke` for Google Container Engine. Leaving it blank (or any othervalue) will disable fast disk options.
+provider: gke
+
+## Storage Class Options
+## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+## If not defined, but provider is gke, will use SSDs
+## Otherwise default: volume.alpha.kubernetes.io/storage-class: default
+#gitlabConfigStorageClass: default
+#gitlabDataStorageClass: default
+#gitlabRegistryStorageClass: default
+#postgresStorageClass: default
+#redisStorageClass: default
+
+healthCheckToken: 'SXBAQichEJasbtDSygrD'
+# Optional, for GitLab EE images only
+#gitlabEELicense: base64-encoded-license
+
+gitlab-runner:
+  checkInterval: 1
+  # runnerRegistrationToken must equal initialSharedRunnersRegistrationToken
+  runnerRegistrationToken: "tQtCbx5UZy_ByS7FyzUH"
+  # resources:
+  #   limits:
+  #     memory: 500Mi
+  #     cpu: 600m
+  #   requests:
+  #     memory: 500Mi
+  #     cpu: 600m
+  runners:
+    privileged: true
+    ## Build Container specific configuration
+    ##
+    # builds:
+    #   cpuLimit: 200m
+    #   memoryLimit: 256Mi
+    #   cpuRequests: 100m
+    #   memoryRequests: 128Mi
+
+    ## Service Container specific configuration
+    ##
+    # services:
+    #   cpuLimit: 200m
+    #   memoryLimit: 256Mi
+    #   cpuRequests: 100m
+    #   memoryRequests: 128Mi
+
+    ## Helper Container specific configuration
+    ##
+    # helpers:
+    #   cpuLimit: 200m
+    #   memoryLimit: 256Mi
+    #   cpuRequests: 100m
+    #   memoryRequests: 128Mi

--- a/docs/deploy-with-ICP.md
+++ b/docs/deploy-with-ICP.md
@@ -1,50 +1,71 @@
 # Deploy with IBM Cloud Private
 
-Another option for getting a Kubernetes cluster up and running is to install
-IBM Cloud Private.
+Another option for getting a Kubernetes cluster up and running is to install IBM Cloud Private.
 
-Follow the directions at https://github.com/IBM/deploy-ibm-cloud-private to
-either install a local instance of IBM Cloud Private via Vagrant or a remote
-instance at Softlayer.  These instructions assume the former.
+## Install IBM Cloud Private
 
-Log into the Vagrant VM
+Follow the directions at https://github.com/IBM/deploy-ibm-cloud-private to either install a local instance of IBM Cloud Private via Vagrant or a remote instance at Softlayer. Complete the optional step of adding an nfs-provisioner to the IBM Cloud Private installation to simplify set up of persistent volumes for the gitlab containers.
 
-```bash
-$ vagrant ssh
-```
+## Install Gitlab on the IBM Cloud Private cluster
 
-Start helm and add the repository
+1.  If you have not done so already, from a workstation install [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) and then [configure for your ICP cluster](https://github.com/IBM/deploy-ibm-cloud-private#accessing-ibm-cloud-private)
 
-```bash
-$ helm init
-$ helm repo add gitlab https://charts.gitlab.io
-```
+2.  Install [Helm](https://github.com/kubernetes/helm) and then initialize:
 
-Install Gitlab
+    ```bash
+    $ helm init --client-only
+    ```
 
-```bash
-$ helm install --name gitlab --set baseDomain=example.com,baseIP=1.1.1.1,gitlab=ce,legoEmail=fake@fake.com gitlab/gitlab-omnibus
-```
+3.  Clone this repository to a local folder.
 
-This will deploy a gitlab installation that includes:
+    ```bash
+    git clone https://github.com/IBM/Kubernetes-container-service-GitLab-sample.git
+    cd Kubernetes-container-service-GitLab-sample
+    ```
 
-    A GitLab Omnibus Pod, including Mattermost, Container Registry, and Prometheus
-    An auto-scaling GitLab Runner using the Kubernetes executor
-    Redis
-    PostgreSQL
-    NGINX Ingress
-    Persistent Volume Claims for Data, Registry, Postgres, and Redis
+4.  Install Gitlab using a helm chart included in this repository. If your Kubernetes cluster has a different dynamic provisioning [StorageClass](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#storageclasses) configured, replace the `nfs-dynamic` value with the name of that storage class.
 
-To access the web UI, first navigate to the list of applications
-(nav menu -> workloads -> applications) and select the "default-http-backend"
-application that is under the  nginx-ingress namespace by clicking on its name.
-Scroll down to the Expose Details section - listed under Endpoint is a link to
-"access 80" - click on it to interact with gitlab through its UI (once it has
-had a chance to spin up).
+    ```bash
+    $ helm install --name gitlab --set baseDomain=example.com,gitlab=ce,legoEmail=fake@fake.com,provider=,gitlabConfigStorageClass=nfs-dynamic,gitlabDataStorageClass=nfs-dynamic,gitlabRegistryStorageClass=nfs-dynamic,postgresStorageClass=nfs-dynamic,redisStorageClass=nfs-dynamic,externalScheme=http charts/gitlab-omnibus
+    ```
 
-# Clean up
+    > This chart is based off the beta [gitlab-omnibus](https://gitlab.com/charts/charts.gitlab.io/tree/master/charts/gitlab-omnibus) chart with some minor modifications to support use of storage classes and setting up a default http scheme for a quick startup without configuring CA-signed TLS certificates.
 
-To uninstall the Gitlab Chart
+    The chart will deploy a gitlab installation that includes:
+
+    *   A GitLab Omnibus Pod, including Mattermost, Container Registry, and Prometheus
+    *   An auto-scaling GitLab Runner using the Kubernetes executor
+    *   Redis
+    *   PostgreSQL
+    *   NGINX Ingress
+    *   Persistent Volume Claims for Data, Registry, Postgres, and Redis
+
+    Depending on the capabilities of the resources hosting the Gitlab cluster, startup time will be 8-15 minutes. You may check on status using the `kubectl get pods` command or the IBM Cloud Private dashboard.
+
+5.  Once started, to access the gitlab Web UI, use the `kubectl` command to find the IP address of the ingress resource:
+
+    ```bash
+    $ kubectl get ingress
+    NAME            HOSTS                                                                        ADDRESS        PORTS     AGE
+    gitlab-gitlab   gitlab.example.com,registry.example.com,mattermost.example.com + 1 more...   169.45.74.56   80, 443   31s
+    ```
+
+6.  Update the workstation /etc/hosts file with an entry for gitlab.example.com with the address shown from the `kubectl get ingress command`:
+
+    ```bash
+    $ cat /etc/hosts
+    127.0.0.1	localhost
+    255.255.255.255	broadcasthost
+    ::1             localhost
+
+    169.45.74.56  gitlab.example.com registry.example.com mattermost.example.com
+    ```
+
+You can proceed to [test out Gitlab by adding a user and a repository](https://github.com/IBM/Kubernetes-container-service-GitLab-sample/blob/master/docs/using-gitlab.md). Note that this gitlab deployment does not expose access to port 22, so use the http protocol for cloning and working with repositories instead of ssh.
+
+## Clean up
+
+To uninstall the Gitlab chart
 
 ```bash
 $ helm delete gitlab


### PR DESCRIPTION
The current deploy-with-ICP instructions stall out on ICP deployed to Vagrant/Softlayer as the gitlab-omnibus chart assumes the presence of GKE dynamic provisioning. This PR includes a customized chart fixing a issue and allowing specification of the scheme through values.yaml. Instructions are expanded and focus on steps performed from a workstation instead of using kubectl and helm on the icp-master.

The instructions reference updates to deploy-ibm-cloud-private here https://github.com/IBM/deploy-ibm-cloud-private/pull/41