### PR TITLE
Add metrics tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,5 +202,23 @@ bx service key-delete "Compose for PostgreSQL-GL" Credentials-1
 bx service delete "Compose for PostgreSQL-GL"
 ```
 
+# Privacy Notice
+
+Sample Kubernetes Yaml file that includes this package may be configured to track deployments to [IBM Cloud](https://www.bluemix.net/) and other Kubernetes platforms. The following information is sent to a [Deployment Tracker](https://github.com/IBM/metrics-collector-service) service on each deployment:
+
+* Kubernetes Cluster Provider(`IBM Cloud,Minikube,etc`)
+* Kubernetes Machine ID
+* Kubernetes Cluster ID (Only from IBM Cloud's cluster)
+* Kubernetes Customer ID (Only from IBM Cloud's cluster)
+* Environment variables in this Kubernetes Job.
+
+This data is collected from the Kubernetes Job in the sample application's yaml file. This data is used by IBM to track metrics around deployments of sample applications to IBM Cloud to measure the usefulness of our examples so that we can continuously improve the content we offer to you. Only deployments of sample applications that include code to ping the Deployment Tracker service will be tracked.
+
+## Disabling Deployment Tracking
+
+Please comment out/remove the Metric Kubernetes Job portion in the 'kubernetes/github.yaml' file.
+
+
 # License
 [Apache 2.0](LICENSE)
+

--- a/kubernetes/gitlab.yaml
+++ b/kubernetes/gitlab.yaml
@@ -79,3 +79,23 @@ spec:
         - name: gitlab
           persistentVolumeClaim:
             claimName: gitlab-claim
+---
+apiVersion: batch/v1
+kind: Job
+metadata: {name: Kubernetes-containter-service-Gitlab-sample-metrics}
+spec:
+  template:
+    metadata: {name: Kubernetes-container-service-Gitlab-sample-metrics}
+    spec:
+      containers:
+        - env:
+            - {name: config, value: '{"repository_id": "Kubernetes-container-
+                  service-Gitlab-sample", "target_runtimes": ["Kubernetes
+                  Cluster"], "event_id": "web", "event_organizer": "dev-
+                  journeys"}'}
+          image: journeycode/kubernetes:latest
+          imagePullPolicy: Always
+          name: Kubernetes-container-service-Gitlab-sample-metrics
+          resources:
+            limits: {cpu: 100m}
+          restartPolicy: Never


### PR DESCRIPTION
This commit adds the metrics tracker from
https://github.com/IBM/metrics-collector-client-kubernetes
