### PR TITLE
Fix ICP link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ see [Deploying Gitlab with Docker](docs/deploy-with-docker.md)
 
 ### Deploy to Kubernetes
 
-Use [Deploying Gitlab to IBM Cloud Private](docs/deploy-with-ICp.md) if you wish to install this on IBM Cloud Private, otherwise follow the instructions below.
+Use [Deploying Gitlab to IBM Cloud Private](docs/deploy-with-ICP.md) if you wish to install this on IBM Cloud Private, otherwise follow the instructions below.
 
 Create a Kubernetes cluster with either [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube) for local testing, or with [IBM Bluemix Container Service](https://github.com/IBM/container-journey-template#container-journey-template---creating-a-kubernetes-cluster) to deploy in cloud. The code here is regularly tested against [Kubernetes Cluster from Bluemix Container Service](https://console.ng.bluemix.net/docs/containers/cs_ov.html#cs_ov) using Travis.
 


### PR DESCRIPTION
ICP was rebranded from ICp a little while back.  This fixes the
the name change in the link in README