### PR TITLE
Disable bx cli version check

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,6 +18,10 @@ curl -LO https://storage.googleapis.com/kubernetes-release/release/"$(curl -s ht
 chmod 0755 kubectl
 sudo mv kubectl /usr/local/bin
 
+echo "Configuring bx to disable version check"
+bx config --check-version=false
+echo "Checking bx version"
+bx --version
 echo "Install the Bluemix container-service plugin"
 bx plugin install container-service -r Bluemix
 


### PR DESCRIPTION
Current Travis builds are failing because of a timeout waiting for
input regarding an update request for the bluemix cli.  This commit
modifies the install.sh script to not check for an update and to
rather use the version downloaded.