### PR TITLE
Fix test-kubernetes

### DIFF
--- a/tests/test-kubernetes.sh
+++ b/tests/test-kubernetes.sh
@@ -27,7 +27,7 @@ kubectl_deploy() {
 
     echo "Waiting for pods to be running"
     i=0
-    while [[ $(kubectl get pods | grep -c Running) -ne 3 ]]; do
+    while [[ $(kubectl get pods -l app=gitlab | grep -c Running) -ne 3 ]]; do
         if [[ ! "$i" -lt 24 ]]; then
             echo "Timeout waiting on pods to be ready"
             test_failed "$0"


### PR DESCRIPTION
The cluster this repo uses for testing runs tests on several
different repositories.  As such, any status checks should only
be looking for pods associated with the gitlab app.