### PR TITLE
Specify shellcheck version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,10 @@ python: 2.7
 cache: pip
 sudo: required
 
+dist: trusty
+
 services:
   - docker
-
-addons:
-  apt:
-    sources:
-      - debian-sid
-    packages:
-      - shellcheck
 
 matrix:
   fast_finish: true
@@ -23,6 +18,9 @@ env:
   - TEST_RUN="./tests/test-kubernetes.sh"
 
 before_install:
+  - curl -sSL "https://ftp-master.debian.org/keys/archive-key-7.0.asc" | sudo -E apt-key add -
+  - echo "deb http://ftp.us.debian.org/debian unstable main contrib non-free" | sudo tee -a /etc/apt/sources.list > /dev/null
+  - sudo apt-get install shellcheck=0.3.3-1~ubuntu14.04.1
   - pip install -U -r test-requirements.txt
 
 install:


### PR DESCRIPTION
Previously, using travis' apt package install for shellcheck was 
breaking builds.  This specifies the shellcheck version and installs 
it. 