### PR TITLE
Add travis notification to slack room

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,13 @@ sudo: required
 
 dist: trusty
 
+notifications:
+  slack:
+    rooms:
+      - "$SLACK_ROOM"
+    on_pull_requests: false
+    on_success: change
+
 services:
   - docker
 


### PR DESCRIPTION
Send build status to slack.  RoomID is stored in travis as an
environment variable