### PR TITLE
Fix persistence issue in GitLab

### DIFF
--- a/kubernetes/gitlab-postgres-svc.yaml
+++ b/kubernetes/gitlab-postgres-svc.yaml
@@ -77,7 +77,11 @@ spec:
               name: gitlab
           volumeMounts:
             - name: gitlab
-              mountPath: /home/git/data:rw
+              mountPath: /var/opt/gitlab
+              subPath: gitlab_data
+            - name: gitlab
+              mountPath: /etc/gitlab
+              subPath: gitlab_configuration
       volumes:
         - name: gitlab
           persistentVolumeClaim:

--- a/kubernetes/gitlab.yaml
+++ b/kubernetes/gitlab.yaml
@@ -74,7 +74,11 @@ spec:
               name: gitlab
           volumeMounts:
             - name: gitlab
-              mountPath: /home/git/data
+              mountPath: /var/opt/gitlab
+              subPath: gitlab_data
+            - name: gitlab
+              mountPath: /etc/gitlab
+              subPath: gitlab_configuration
       volumes:
         - name: gitlab
           persistentVolumeClaim:


### PR DESCRIPTION
This fixes persistence issue in GitLab. This commit properly mounts the correct container location in the gitlab container.
Source of documentation: https://docs.gitlab.com/omnibus/docker/#where-is-the-data-stored.

Previously when restarting the gitlab pod, we lose all the repository/project's contents. This commit also persists the GitLab configuration files.

Signed-off-by: AnthonyAmanse <ghieamanse@gmail.com>