### PR TITLE
Travis CI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
 
 env:
   - TEST_RUN="./tests/test-docker-compose.sh"
-  - TEST_RUN="./tests/test-kubeadm-dind-cluster.sh"
+  - TEST_RUN="./tests/test-minikube.sh"
   - TEST_RUN="./tests/test-kubernetes.sh"
 
 before_install:

--- a/tests/test-kubernetes.sh
+++ b/tests/test-kubernetes.sh
@@ -8,8 +8,9 @@ source "$(dirname "$0")"/../scripts/resources.sh
 
 kubeclt_clean() {
     echo "Cleaning cluster"
+    kubectl delete pvc,deployment,service,replicaset -l app=gitlab
+    sleep 30s
     kubectl delete pv local-volume-1 local-volume-2 local-volume-3
-    kubectl delete deployment,service,pvc,replicaset -l app=gitlab
 }
 
 kubectl_config() {


### PR DESCRIPTION
Improve cleaning of kubernetes resource. Persistent volume claims need to be deleted first so that recycler pods will actually clean the nodes' data in the specified `hostPath`.

Switch `kubeadm-dind` cluster to a minikube environment. Kubernetes test would now be performed in minikube.