### PR TITLE
Simplify shellcheck install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,7 @@ env:
   - TEST_RUN="./tests/test-kubernetes.sh"
 
 before_install:
-  - curl -sSL "https://ftp-master.debian.org/keys/archive-key-7.0.asc" | sudo -E apt-key add -
-  - echo "deb http://ftp.us.debian.org/debian unstable main contrib non-free" | sudo tee -a /etc/apt/sources.list > /dev/null
-  - sudo apt-get install shellcheck=0.3.3-1~ubuntu14.04.1
+  - sudo apt-get install shellcheck
   - pip install -U -r test-requirements.txt
 
 install:


### PR DESCRIPTION
Previously, shellcheck was installed from debian packages.  It is
now in ubuntu packages, so use them.