### PR TITLE
Modify README to use Cloud Native deployment

### DIFF
--- a/config-persistent.yaml
+++ b/config-persistent.yaml
@@ -1,0 +1,56 @@
+---
+# note: this is using a forked repo of
+# the gitlab chart for minio security context
+# https://gitlab.com/AnthonyAmanse/gitlab
+global:
+  hosts:
+    domain: <INGRESS_SUBDOMAIN>
+    externalIP: <ALB_IP>
+  ingress:
+    configureCertmanager: false
+    tls:
+      secretName: <INGRESS_SECRET>
+    class: ""
+    annotations:
+      ingress.bluemix.net/client-max-body-size: size=0
+  edition: ce
+
+gitlab:
+  gitaly:
+    persistence:
+      size: 20Gi
+      storageClass: ibmc-file-gold
+    securityContext:
+      runAsUser: 0
+
+postgresql:
+  persistence:
+    size: 20Gi
+    storageClass: ibmc-file-gold
+  securityContext:
+    runAsUser: 0
+  metrics:
+    enabled: false
+
+minio:
+  persistence:
+    size: 20Gi
+    storageClass: ibmc-file-gold
+  securityContext:
+    runAsUser: 0
+
+redis:
+  persistence:
+    size: 20Gi
+    storageClass: ibmc-file-gold
+  securityContext:
+    runAsUser: 0
+
+certmanager:
+  install: false
+
+nginx-ingress:
+  enabled: false
+
+prometheus:
+  install: false

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,41 @@
+---
+global:
+  hosts:
+    domain: <INGRESS_SUBDOMAIN>
+    externalIP: <ALB_IP>
+  ingress:
+    configureCertmanager: false
+    tls:
+      secretName: <INGRESS_SECRET>
+    class: ""
+    annotations:
+      ingress.bluemix.net/client-max-body-size: size=0
+  edition: ce
+
+gitlab:
+  gitaly:
+    persistence:
+      enabled: false
+
+postgresql:
+  persistence:
+    enabled: false
+  metrics:
+    enabled: false
+
+minio:
+  persistence:
+    enabled: false
+
+redis:
+  persistence:
+    enabled: false
+
+certmanager:
+  install: false
+
+nginx-ingress:
+  enabled: false
+
+prometheus:
+  install: false

--- a/docs/ssh-port-ingress.md
+++ b/docs/ssh-port-ingress.md
@@ -1,0 +1,52 @@
+# Expose SSH Port with Ingress Controller in IKS
+
+1. Edit configmap for ALB (Application Load Balancer)
+
+```
+$ kubectl edit configmap ibm-cloud-provider-ingress-cm -n kube-system
+```
+
+Add port `22` in the public ports:
+
+```
+...
+data:
+  public-ports: 80;443;22
+...
+```
+
+2. Edit Ingress of GitLab
+
+```
+$ kubectl edit ingress gitlab-unicorn
+```
+
+Add this in one of the annotations:
+
+```
+...
+annotations:
+  ingress.bluemix.net/tcp-ports: "serviceName=gitlab-gitlab-shell ingressPort=22"
+...
+```
+
+3. Verify
+
+First, verify if the ALB is exposing the `22` port.
+
+```
+$ kubectl get service -n kube-system
+
+NAME                                             TYPE           CLUSTER-IP       EXTERNAL-IP    PORT(S)                                   AGE
+...
+public-cr486e6497c6da4d5ca3b15edb99e216fe-alb1   LoadBalancer   172.21.130.120   169.XX.XX.XX   80:31256/TCP,443:32340/TCP,22:30917/TCP   47d                        4d
+```
+
+Next, verify if you can ssh with the ingress subdomain _(Assuming you already have registered and added an SSH key in your GitLab deployment)_:
+> Use your own Ingress Subdomain `gitlab.<INGRESS_SUBDOMAIN>`
+
+```
+$ ssh -T git@gitlab.anthony-dev.us-south.containers.appdomain.cloud
+
+Welcome to GitLab, @anthony!
+```


### PR DESCRIPTION
This commit modifies the README that uses the new cloud native
deployment for GitLab. This commit also adds in documentation for
exposing the SSH port with the provided ingress controller for IKS.

Signed-off-by: AnthonyAmanse <ghieamanse@gmail.com>