### PR TITLE
Update 'License' section text in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,5 +172,9 @@ $ helm delete gitlab --purge
 ```
 
 # License
-[Apache 2.0](LICENSE)
+
+This code pattern is licensed under the Apache Software License, Version 2. Separate third party code objects invoked within this code pattern are licensed by their respective providers pursuant to their own separate licenses. Contributions are subject to the Developer [Certificate of Origin, Version 1.1](https://developercertificate.org/) (“DCO”) and the [Apache Software License, Version 2](LICENSE).
+
+ASL FAQ link: http://www.apache.org/foundation/license-faq.html#WhatDoesItMEAN
+
 

--- a/docs/deploy-with-docker.md
+++ b/docs/deploy-with-docker.md
@@ -2,7 +2,7 @@
 
 ## 1. Install Docker CLI 
 
-First, install [Docker](https://www.docker.com) by following the instructions [here](https://www.docker.com/community-edition#/download) for your preferrerd operating system.
+First, install [Docker](https://www.docker.com) by following the instructions [here](https://www.docker.com/community-edition#/download) for your preferred operating system.
 
 ## Single Container deployment via Docker
 


### PR DESCRIPTION
Add DCO and ASL FAQ links under the 'License' section of the README.
Fix a typo.