### PR TITLE
Remove sudo and dist tags from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@
 language: python
 python: 2.7
 cache: pip
-sudo: required
-
-dist: trusty
 
 notifications:
   webhooks: https://openwhisk.ng.bluemix.net/api/v1/namespaces/Developer%20Advocacy_Cloud%20Developer%20Advocacy/actions/travisreporting-olaph/processbuild


### PR DESCRIPTION
Remove 'sudo: required' and 'dist: trusty' from the .travis.yml file. Both are depricated. Fixes #94