### PR TITLE
Increase wait time for kubernetes test

### DIFF
--- a/tests/test-kubernetes.sh
+++ b/tests/test-kubernetes.sh
@@ -41,7 +41,7 @@ kubectl_deploy() {
     echo "All pods are running"
 
     echo "Waiting for service to be available"
-    sleep 120
+    sleep 240
 }
 
 verify_deploy(){


### PR DESCRIPTION
When testing on IKS, the current script does not wait long enough
for the gitlab app to initalize before checking if it is available.
This commit increases the wait time from 2 minutes to 4.